### PR TITLE
Update json for esphome compiler errors

### DIFF
--- a/models/computer/computer.json
+++ b/models/computer/computer.json
@@ -4,6 +4,9 @@
   "author": "Leland Olney",
   "website": "https://github.com/JohnnyPrimus/Custom_V2_MicroWakeWords",
   "model": "computer.tflite",
+  "trained_languages": [
+    "en"
+  ],
   "version": 2,
   "micro": {
     "probability_cutoff": 0.66,

--- a/models/computer/computer.json
+++ b/models/computer/computer.json
@@ -13,6 +13,6 @@
     "sliding_window_size": 10,
     "feature_step_size": 10,
     "tensor_arena_size": 22860,
-    "minimum_esphome_version": "2024.7"
+    "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/computer/computer.json
+++ b/models/computer/computer.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 36000,
+    "tensor_arena_size": 25536,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/computer/computer.json
+++ b/models/computer/computer.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 25536,
+    "tensor_arena_size": 25544,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/computer/computer.json
+++ b/models/computer/computer.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 22860,
+    "tensor_arena_size": 36000,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/computer/computer.json
+++ b/models/computer/computer.json
@@ -10,7 +10,7 @@
   "version": 2,
   "micro": {
     "probability_cutoff": 0.66,
-    "sliding_window_average_size": 10,
+    "sliding_window_size": 10,
     "feature_step_size": 10,
     "tensor_arena_size": 22860,
     "minimum_esphome_version": "2024.7"

--- a/models/hey_friday/hey_friday.json
+++ b/models/hey_friday/hey_friday.json
@@ -13,6 +13,6 @@
     "sliding_window_size": 10,
     "feature_step_size": 10,
     "tensor_arena_size": 22860,
-    "minimum_esphome_version": "2024.7"
+    "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/hey_friday/hey_friday.json
+++ b/models/hey_friday/hey_friday.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 36000,
+    "tensor_arena_size": 25536,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/hey_friday/hey_friday.json
+++ b/models/hey_friday/hey_friday.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 25536,
+    "tensor_arena_size": 25544,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/hey_friday/hey_friday.json
+++ b/models/hey_friday/hey_friday.json
@@ -4,6 +4,9 @@
   "author": "NathanCu@community.home-assistant.io",
   "website": "https://github.com/JohnnyPrimus/Custom_V2_MicroWakeWords",
   "model": "hey_friday.tflite",
+  "trained_languages": [
+    "en"
+  ],
   "version": 2,
   "micro": {
     "probability_cutoff": 0.66,

--- a/models/hey_friday/hey_friday.json
+++ b/models/hey_friday/hey_friday.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 22860,
+    "tensor_arena_size": 36000,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/hey_friday/hey_friday.json
+++ b/models/hey_friday/hey_friday.json
@@ -10,7 +10,7 @@
   "version": 2,
   "micro": {
     "probability_cutoff": 0.66,
-    "sliding_window_average_size": 10,
+    "sliding_window_size": 10,
     "feature_step_size": 10,
     "tensor_arena_size": 22860,
     "minimum_esphome_version": "2024.7"

--- a/models/hey_wabi/hey_wabi.json
+++ b/models/hey_wabi/hey_wabi.json
@@ -13,6 +13,6 @@
     "sliding_window_size": 10,
     "feature_step_size": 10,
     "tensor_arena_size": 22860,
-    "minimum_esphome_version": "2024.7"
+    "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/hey_wabi/hey_wabi.json
+++ b/models/hey_wabi/hey_wabi.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 36000,
+    "tensor_arena_size": 25536,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/hey_wabi/hey_wabi.json
+++ b/models/hey_wabi/hey_wabi.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 25536,
+    "tensor_arena_size": 25544,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/hey_wabi/hey_wabi.json
+++ b/models/hey_wabi/hey_wabi.json
@@ -4,6 +4,9 @@
   "author": "Leland Olney",
   "website": "https://github.com/JohnnyPrimus/Custom_V2_MicroWakeWords",
   "model": "hey_wabi.tflite",
+  "trained_languages": [
+    "en"
+  ],
   "version": 2,
   "micro": {
     "probability_cutoff": 0.66,

--- a/models/hey_wabi/hey_wabi.json
+++ b/models/hey_wabi/hey_wabi.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.66,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 22860,
+    "tensor_arena_size": 36000,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/hey_wabi/hey_wabi.json
+++ b/models/hey_wabi/hey_wabi.json
@@ -10,7 +10,7 @@
   "version": 2,
   "micro": {
     "probability_cutoff": 0.66,
-    "sliding_window_average_size": 10,
+    "sliding_window_size": 10,
     "feature_step_size": 10,
     "tensor_arena_size": 22860,
     "minimum_esphome_version": "2024.7"

--- a/models/wasabi/wasabi.json
+++ b/models/wasabi/wasabi.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.33,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 36000,
+    "tensor_arena_size": 25024,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/wasabi/wasabi.json
+++ b/models/wasabi/wasabi.json
@@ -4,6 +4,9 @@
   "author": "Leland Olney",
   "website": "https://github.com/JohnnyPrimus/Custom_V2_MicroWakeWords",
   "model": "wasabi.tflite",
+  "trained_languages": [
+    "en"
+  ],
   "version": 2,
   "micro": {
     "probability_cutoff": 0.33,

--- a/models/wasabi/wasabi.json
+++ b/models/wasabi/wasabi.json
@@ -13,6 +13,6 @@
     "sliding_window_size": 10,
     "feature_step_size": 10,
     "tensor_arena_size": 22860,
-    "minimum_esphome_version": "2024.7"
+    "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/wasabi/wasabi.json
+++ b/models/wasabi/wasabi.json
@@ -10,7 +10,7 @@
   "version": 2,
   "micro": {
     "probability_cutoff": 0.33,
-    "sliding_window_average_size": 10,
+    "sliding_window_size": 10,
     "feature_step_size": 10,
     "tensor_arena_size": 22860,
     "minimum_esphome_version": "2024.7"

--- a/models/wasabi/wasabi.json
+++ b/models/wasabi/wasabi.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.33,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 22860,
+    "tensor_arena_size": 36000,
     "minimum_esphome_version": "2024.7.0"
   }
 }

--- a/models/wasabi/wasabi.json
+++ b/models/wasabi/wasabi.json
@@ -12,7 +12,7 @@
     "probability_cutoff": 0.33,
     "sliding_window_size": 10,
     "feature_step_size": 10,
-    "tensor_arena_size": 25024,
+    "tensor_arena_size": 25032,
     "minimum_esphome_version": "2024.7.0"
   }
 }


### PR DESCRIPTION
I was getting the `[micro_wake_word] is an invalid option for [<root>]` error like in https://github.com/JohnnyPrimus/Custom_V2_MicroWakeWords/issues/2.  Taking a look at the json I noticed a few differences from the [docs](https://esphome.io/components/micro_wake_word.html#model-json). It still didn't work for me until I updated the `minimum_esphome_version` to match the [official ones](https://github.com/esphome/micro-wake-word-models/blob/main/models/v2/okay_nabu.json) with the fully qualified version.

~I can compile now but have a new error I'll follow up with 😅~

---
 
Edit: Fixed the tensor allocation error by bumping up the `tensor_arena_size`. The amount can be found with the [arena_used_bytes](https://github.com/tensorflow/tflite-micro/blob/9b79b9faf208fddb509a0efc671bf338b5675ab9/tensorflow/lite/micro/micro_interpreter.h#L140-L146) function.  From the comment there, if the returned value isn't divisible by 16 add another 16 to it.

I'm checking the value with https://github.com/genehand/esphome/commit/bf70c81a91e829230a1ecfc5216e6db00797c730